### PR TITLE
Fix carrier status for ttdp aggregates.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([libteam], [1.31-wmo5], [mika.juvonen@westermo.com])
+AC_INIT([libteam], [1.31-wmo6], [mika.juvonen@westermo.com])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])

--- a/teamd/teamd_runner_ttdp.c
+++ b/teamd/teamd_runner_ttdp.c
@@ -994,9 +994,11 @@ static int elect_neighbor(struct teamd_context *ctx, struct ab *ab, uint8_t *nex
 			memcpy(&candidate_last, candidate_mac + 4, 2);
 			if (candidate_first == 0 && candidate_last == 0) {
 				ab->neighbor_is_none = 1;
+				team_carrier_set(ctx->th, false);
 				teamd_ttdp_log_infox(ctx->team_devname, "Null-MAC set as neighbor.");
 			} else {
 				ab->neighbor_is_none = 0;
+				team_carrier_set(ctx->th, true);
 			}
 
 			lag_state_write_diag_crossed_lines_detected(ctx, ab);


### PR DESCRIPTION
Having correct carrier status allows for utilization of
ttdp aggregates in vlans when  they are logically
down whilst physically up.