### PR TITLE
Late send detection

### DIFF
--- a/teamd/teamd.c
+++ b/teamd/teamd.c
@@ -41,6 +41,7 @@
 #include <private/list.h>
 #include <private/misc.h>
 #include <team.h>
+#include <sys/resource.h>
 
 #include "config.h"
 #include "teamd.h"
@@ -1814,6 +1815,9 @@ int main(int argc, char **argv)
 	enum teamd_exit_code ret = TEAMD_EXIT_FAILURE;
 	int err;
 	struct teamd_context *ctx;
+
+	nice(-20);
+	setpriority(PRIO_PROCESS, 0, -20);
 
 	err = teamd_make_rundir();
 	if (err)

--- a/teamd/teamd_lw_ttdp.h
+++ b/teamd/teamd_lw_ttdp.h
@@ -24,6 +24,7 @@
 
 #include <linux/netdevice.h>
 #include <linux/if_ether.h>
+#include <time.h>
 
 #include "teamd_workq.h"
 
@@ -253,6 +254,10 @@ struct lw_ttdp_port_priv {
 
 	/* This is the socket used for sending data. */
 	int out_sock;
+
+	uint32_t last_ok_lifesign;
+	struct timespec last_xmit;
+	int fast_reply;
 };
 
 /* Structure that holds all data for a single neighbor. */

--- a/teamd/teamd_runner_ttdp.c
+++ b/teamd/teamd_runner_ttdp.c
@@ -2902,7 +2902,7 @@ const struct teamd_runner teamd_runner_ttdp = {
 #ifdef MODE_ACTIVEBACKUP
 	.team_mode_name	= "activebackup",
 #else
-	.team_mode_name	= "random",
+	.team_mode_name	= "loadbalance",
 #endif
 	.priv_size		= sizeof(struct ab),
 	.init			= ab_init,
@@ -2914,7 +2914,7 @@ const struct teamd_runner teamd_runner_ttdp_s4r = {
 #ifdef MODE_ACTIVEBACKUP
 	.team_mode_name	= "activebackup",
 #else
-	.team_mode_name	= "random",
+	.team_mode_name	= "loadbalance",
 #endif
 	.priv_size		= sizeof(struct ab),
 	.init			= ab_init_s4r,


### PR DESCRIPTION
This change renices the teamd process to -20, and adds debug logging for then the frame send function in the TTDP linkwatcher is called too late. When this happens, the peer will likely consider the local node as missing, which will result in a loss of connectivity.

Additionally, we use the "loadbalance" mode by default, which we should have been doing all along.