### PR TITLE
Kernel upgrade related fixes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([libteam], [1.31-wmo8], [mika.juvonen@westermo.com])
+AC_INIT([libteam], [1.31-wmo9], [mika.juvonen@westermo.com])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])

--- a/teamd/teamd.c
+++ b/teamd/teamd.c
@@ -1563,18 +1563,19 @@ static int teamd_start(struct teamd_context *ctx, enum teamd_exit_code *p_ret)
 		goto pid_file_remove;
 	}
 
-	if (daemon_pid_file_create() < 0) {
-		teamd_log_err("Could not create PID file.");
-		daemon_retval_send(errno);
-		return -errno;
-	}
-
 	err = teamd_init(ctx);
 	if (err) {
 		teamd_log_err("teamd_init() failed.");
 		daemon_retval_send(-err);
 		goto signal_done;
 	}
+
+	if (daemon_pid_file_create() < 0) {
+		teamd_log_err("Could not create PID file.");
+		daemon_retval_send(errno);
+		return -errno;
+	}
+
 	*p_ret = TEAMD_EXIT_RUNTIME_FAILURE;
 
 	daemon_retval_send(0);

--- a/teamd/teamd_per_port.c
+++ b/teamd/teamd_per_port.c
@@ -217,7 +217,6 @@ static void port_obj_remove(struct teamd_context *ctx,
 	struct teamd_port *tdport = _port(port_obj);
 
 	teamd_event_port_removed(ctx, tdport);
-	teamd_port_remove(ctx, tdport);
 	port_obj_destroy(ctx, port_obj);
 	port_obj_free(port_obj);
 }


### PR DESCRIPTION
Generate the PID after the ports are aggregated.
Do not destroy port when no quit destroy is enabled.